### PR TITLE
Fix bug when grid snap breaks duration lines

### DIFF
--- a/src/EditorUI.cpp
+++ b/src/EditorUI.cpp
@@ -2,6 +2,8 @@
 #include <Geode/modify/EditorUI.hpp>
 #include "../include/DrawGridAPI.hpp"
 
+using namespace geode::prelude;
+
 class $modify(MyEditorUI, EditorUI) {
 	void updateZoom(float p0) {
 		EditorUI::updateZoom(p0);

--- a/src/EditorUI.cpp
+++ b/src/EditorUI.cpp
@@ -7,4 +7,25 @@ class $modify(MyEditorUI, EditorUI) {
 		EditorUI::updateZoom(p0);
 		DrawGridAPI::get().markDirty();
 	}
+
+	// fix bug when grid snap breaks the duration lines
+	void ccTouchEnded(CCTouch* p0, CCEvent* p1) {
+		bool shouldUpdateEndPos = (
+			p0->m_nId != m_rotationTouchID && 
+			p0->m_nId != m_scaleTouchID && 
+			p0->m_nId != m_transformTouchID && 
+			p0->m_nId == m_touchID && 
+			m_snapObjectExists && 
+			m_continuousSnap && 
+			m_snapObject && 
+			GameManager::get()->getGameVariable("0008") && 
+			(int)m_snapObject->getRotation() % 90 == 0
+		);
+	
+		EditorUI::ccTouchEnded(p0, p1);
+	
+		if (shouldUpdateEndPos) {
+			m_editorLayer->m_drawGridLayer->m_updateTimeMarkers = true;
+		}
+	}
 };


### PR DESCRIPTION
# Before

https://github.com/user-attachments/assets/8a6b5b70-ef2e-410e-966b-afb86e48ecd2

# After

https://github.com/user-attachments/assets/ac3a4a4a-8739-491b-97f5-7c562e38422b

